### PR TITLE
Save progress in the pattern-position between calls to search_simple

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,65 @@ fn assert_perfect_decomposition<T: Eq>(k: usize, u: &[T], v: &[T]) {
     // ok
 }
 
+/// Search `text` for the `pattern` with the requirement that the pattern
+/// is k-simple; which means it has at most one k-HRP.
+///
+/// `start_pos` is the position to start the search, and it is updated after
+/// the function returns with a match.
+fn search_simple<T: Eq>(text: &[T], pattern: &[T],
+                        start_pos: &mut usize,
+                        start_j: &mut usize,
+                        hrp1: &Option<Hrp>)
+    -> Option<usize>
+{
+    debug_assert!(pattern.len() <= text.len());
+    debug_assert_eq!(hrp(1, pattern, None), (*hrp1, None));
+
+    let n = text.len();
+    let m = pattern.len();
+
+    let (has_scope, scope_l, scope_r) = if let Some(hrp1) = *hrp1 {
+        // Scope of the k-HRP1 is [L, R]
+        // where
+        //  L = |v²| = 2 × period
+        //  R = z = length of prefix
+        //
+        // See Lemma 2 in [CR]:
+        //
+        // Any nonempty prefix u of x satisfies
+        //
+        // per(u) = Li / 2 if |u| is in [Li, Ri] for some i
+        // per(u) > |u| / k if not
+        //
+        let scope_l = hrp1.period * 2;
+        let scope_r = hrp1.len;
+        debug_assert!(scope_l <= scope_r);
+        (true, scope_l, scope_r)
+    } else {
+        (false, 0, 0)
+    };
+
+    let mut pos = *start_pos; // text position
+    let mut j = *start_j;     // pattern position
+    while pos <= n - m {
+        j = longest_common_prefix_from(j, get!(text, pos..), pattern);
+        let has_match = if j == m { Some(pos) } else { None };
+        if has_scope && j >= scope_l && j <= scope_r {
+            pos += scope_l / 2;
+            j -= scope_l / 2;
+        } else {
+            pos += j / GS_K + 1;
+            j = 0;
+        }
+        if let Some(match_pos) = has_match {
+            *start_pos = pos;
+            *start_j = j;
+            return Some(match_pos);
+        }
+    }
+    None
+}
+
 
 /// This is the Galil-Seiferas string matching algorithm.
 ///
@@ -575,65 +634,6 @@ fn test_find_fuzz_2() {
                aababaab\xffaabaabaab\x00\x00\xff\x28\xffaab\xffaabaabaab\x00\
                \x00\xff\x28\xff";
     assert_find_substring!(data, 21..21 + 68);
-}
-
-/// Search `text` for the `pattern` with the requirement that the pattern
-/// is k-simple; which means it has at most one k-HRP.
-///
-/// `start_pos` is the position to start the search, and it is updated after
-/// the function returns with a match.
-fn search_simple<T: Eq>(text: &[T], pattern: &[T],
-                        start_pos: &mut usize,
-                        start_j: &mut usize,
-                        hrp1: &Option<Hrp>)
-    -> Option<usize>
-{
-    debug_assert!(pattern.len() <= text.len());
-    debug_assert_eq!(hrp(1, pattern, None), (*hrp1, None));
-
-    let n = text.len();
-    let m = pattern.len();
-
-    let (has_scope, scope_l, scope_r) = if let Some(hrp1) = *hrp1 {
-        // Scope of the k-HRP1 is [L, R]
-        // where
-        //  L = |v²| = 2 × period
-        //  R = z = length of prefix
-        //
-        // See Lemma 2 in [CR]:
-        //
-        // Any nonempty prefix u of x satisfies
-        //
-        // per(u) = Li / 2 if |u| is in [Li, Ri] for some i
-        // per(u) > |u| / k if not
-        //
-        let scope_l = hrp1.period * 2;
-        let scope_r = hrp1.len;
-        debug_assert!(scope_l <= scope_r);
-        (true, scope_l, scope_r)
-    } else {
-        (false, 0, 0)
-    };
-
-    let mut pos = *start_pos; // text position
-    let mut j = *start_j;     // pattern position
-    while pos <= n - m {
-        j = longest_common_prefix_from(j, get!(text, pos..), pattern);
-        let has_match = if j == m { Some(pos) } else { None };
-        if has_scope && j >= scope_l && j <= scope_r {
-            pos += scope_l / 2;
-            j -= scope_l / 2;
-        } else {
-            pos += j / GS_K + 1;
-            j = 0;
-        }
-        if let Some(match_pos) = has_match {
-            *start_pos = pos;
-            *start_j = j;
-            return Some(match_pos);
-        }
-    }
-    None
 }
 
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -827,6 +827,54 @@ mod benches {
     }
 
     #[bench]
+    fn bench_gs_find_itself4(b: &mut Bencher) {
+        let haystack = "this is actually a longer text where them xxxx xxxxx\
+            could be tricked by and so on.".repeat(10) + "itself.";
+        let pattern = "itself";
+
+        b.iter(|| {
+            gs_find(haystack.as_bytes(), pattern.as_bytes())
+        });
+        b.bytes = haystack.len() as u64;
+    }
+
+    #[bench]
+    fn bench_brute_itself4(b: &mut Bencher) {
+        let haystack = "this is actually a longer text where them xxxx xxxxx\
+            could be tricked by and so on.".repeat(10) + "itself.";
+        let pattern = "itself";
+
+        b.iter(|| {
+            brute_force_search(haystack.as_bytes(), pattern.as_bytes())
+        });
+        b.bytes = haystack.len() as u64;
+    }
+
+    #[bench]
+    fn bench_gs_find_itself5(b: &mut Bencher) {
+        let haystack = "this is actually a longer text where them itsel itselg\
+            could be tricked by and so on.".repeat(10) + "itself.";
+        let pattern = "itself";
+
+        b.iter(|| {
+            gs_find(haystack.as_bytes(), pattern.as_bytes())
+        });
+        b.bytes = haystack.len() as u64;
+    }
+
+    #[bench]
+    fn bench_brute_itself5(b: &mut Bencher) {
+        let haystack = "this is actually a longer text where them itsel itselg\
+            could be tricked by and so on.".repeat(10) + "itself.";
+        let pattern = "itself";
+
+        b.iter(|| {
+            brute_force_search(haystack.as_bytes(), pattern.as_bytes())
+        });
+        b.bytes = haystack.len() as u64;
+    }
+
+    #[bench]
     fn bench_gs_strings_bad(b: &mut Bencher) {
         let n = 50;
         let haystack_s = ("bacbax".repeat(n - 1) + "bbbbb").repeat(n);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -18,17 +18,29 @@ impl<'a> fmt::Display for Bytestring<'a, u8> {
 }
 
 #[cfg(any(test, feature = "test-functions"))]
-// using memcmp, so relatively fast but naive search
 pub fn brute_force_search<T: Eq>(text: &[T], pattern: &[T]) -> Option<usize> {
     let n = text.len();
     let m = pattern.len();
     if n < m {
         return None;
     }
-    for i in 0..n - m + 1 {
-        if &text[i .. i + m] == pattern {
+    'outer: for i in 0..n - m + 1 {
+
+        /* to use memcmp:
+         * it's a tradeoff; memcmp is faster with more pathological-y inputs!
+         * for relistic inputs where we quickly find a mismatch at most
+         * postions, it's faster using just single element get.
+        if get!(text, i .. i + m) == pattern {
             return Some(i);
         }
+        */
+
+        for j in 0..m {
+            if get!(text, i + j) != get!(pattern, j) {
+                continue 'outer;
+            }
+        }
+        return Some(i);
     }
     None
 }


### PR DESCRIPTION
search_simple uses pos (text position) and j (pattern position); save
j across calls to search_simple too, which should save time if we have
a periodic pattern.

Most testing/benchmarking is using byte strings, but this change on
the average will save comparisons, which is better the more expensive
the comparison function is.

All of the benchmarks are susceptible to noise or the luck of the optimization.

This is a minor win, especially when we can save comparisons (see strings_good)

```
 name                               old2 ns/iter       new ns/iter        diff ns/iter  diff %
 benches::bench_gs_find_itself1     19 (315 MB/s)      19 (315 MB/s)                 0   0.00%
 benches::bench_gs_find_itself2     40 (375 MB/s)      39 (384 MB/s)                -1  -2.50%
 benches::bench_gs_find_itself3     1,907 (433 MB/s)   1,850 (447 MB/s)            -57  -2.99%
 benches::bench_gs_periodic2_10     435 (459 MB/s)     438 (456 MB/s)                3   0.69%
 benches::bench_gs_periodic2_50     8,928 (560 MB/s)   8,922 (560 MB/s)             -6  -0.07%
 benches::bench_gs_periodic2_large  32,754 (610 MB/s)  32,746 (610 MB/s)            -8  -0.02%
 benches::bench_gs_periodic5_50     14,054 (889 MB/s)  13,666 (914 MB/s)          -388  -2.76%
 benches::bench_gs_strings_bad      15,108             14,710                     -398  -2.63%
 benches::bench_gs_strings_good     903                864                         -39  -4.32%
```

Benchmarks from the twoway repo show mixed results:

What I see below is that progress in j improves searches on more
"realistic" inputs, improves on some pathological inputs and regresses
on other pathological inputs. Looks like a win overall.

```
 name                               gs_old_merged ns/iter  gs_new_merged ns/iter  diff ns/iter   diff %
 aaab_in_aab::gs_find               715,095 (419 MB/s)     840,340 (356 MB/s)          125,245   17.51%
 aaabbb::gs_find                    785,531 (381 MB/s)     839,700 (357 MB/s)           54,169    6.90%
 allright::gs_find                  298,098 (603 MB/s)     257,425 (699 MB/s)          -40,673  -13.64%
 bb_in_aa::gs_find                  162,689 (614 MB/s)     163,106 (613 MB/s)              417    0.26%
 bbbaaa::gs_find                    704,339 (425 MB/s)     731,399 (410 MB/s)           27,060    3.84%
 gllright::gs_find                  311,963 (576 MB/s)     331,174 (543 MB/s)           19,211    6.16%
 naive::gs_find                     619 (403 MB/s)         624 (400 MB/s)                    5    0.81%
 naive_longpat::gs_find             244,659 (408 MB/s)     245,232 (407 MB/s)              573    0.23%
 naive_longpat_reversed::gs_find    108,635 (920 MB/s)     108,431 (922 MB/s)             -204   -0.19%
 naive_rev::gs_find                 295 (847 MB/s)         293 (853 MB/s)                   -2   -0.68%
 pathological_two_way::gs_find      65,069 (922 MB/s)      65,048 (922 MB/s)               -21   -0.03%
 pathological_two_way_rev::gs_find  119,227 (503 MB/s)     86,722 (691 MB/s)           -32,505  -27.26%
 periodic2::gs_find                 31,647 (631 MB/s)      32,559 (614 MB/s)               912    2.88%
 periodic5::gs_find                 8,665 (923 MB/s)       9,063 (882 MB/s)                398    4.59%
 short_1let_cy::gs_find             14,503 (353 MB/s)      13,271 (386 MB/s)            -1,232   -8.49%
 short_1let_long::gs_find           2,785 (915 MB/s)       2,782 (916 MB/s)                 -3   -0.11%
 short_2let_common::gs_find         4,947 (515 MB/s)       4,433 (575 MB/s)               -514  -10.39%
 short_2let_cy::gs_find             16,462 (311 MB/s)      15,323 (334 MB/s)            -1,139   -6.92%
 short_2let_rare::gs_find           3,165 (806 MB/s)       3,080 (828 MB/s)                -85   -2.69%
 short_3let_cy::gs_find             16,419 (312 MB/s)      15,218 (337 MB/s)            -1,201   -7.31%
 short_3let_long::gs_find           4,618 (552 MB/s)       4,255 (599 MB/s)               -363   -7.86%
 short_short::gs_find               111 (504 MB/s)         85 (658 MB/s)                   -26  -23.42%
 short_word1_long::gs_find          4,696 (543 MB/s)       4,323 (590 MB/s)               -373   -7.94%
 short_word2_long::gs_find          4,333 (588 MB/s)       4,014 (635 MB/s)               -319   -7.36%
```

